### PR TITLE
Fix for 1.12

### DIFF
--- a/mgsv_fov/hook_wrapper.asm
+++ b/mgsv_fov/hook_wrapper.asm
@@ -12,10 +12,30 @@ hook_decrypt_wrap proc
 hook_decrypt_wrap endp
 
 hook_update_fov_lerp_wrap proc
-	push rcx
-	call hook_update_fov_lerp
-	pop rcx
-	ret
+	push rcx				  ; 1 byte
+	call hook_update_fov_lerp ; 5 bytes
+	pop rcx					  ; 1 byte
+
+	; for the instructions we overwrote with our trampoline
+	; MUST match patch size!
+	; make sure trampoline size lies on instruction boundary in original code
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+	nop
+
+	; will be overwritten with our return address
+	; instruction start + 2 bytes for address
+	mov rax, 1234567890ABCDEFh
+	jmp rax
 hook_update_fov_lerp_wrap endp
 
 end

--- a/mgsv_fov/mgsv_fov.vcxproj
+++ b/mgsv_fov/mgsv_fov.vcxproj
@@ -67,7 +67,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <TargetExt>.dll</TargetExt>
-    <TargetName>steam_api64</TargetName>
+    <TargetName>d3d11</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <TargetExt>.dll</TargetExt>


### PR DESCRIPTION
Fixes #2 

The initial method (writing back into unused int3) stopped working, as the trampoline size became larger than the free space. Clobbering the previous function caused a crash.

Now, the hook function is
- jumped to instead of called
- jumped to from the entry address of the original function, overwriting the code that was there
- padded with nops, which are later filled with the original function's instructions

This makes the assumption that 12 bytes (trampoline size) of instructions in the original will always fall on an instruction boundary. It also makes the assumption that nothing messes with rax in those first ops. I'm hopeful this remains the case.